### PR TITLE
Fix .travis.yml for deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ node_js:
 script:
 - npm run test
 deploy:
+  provider: npm
+  email: systems@azavea.com
   api_key:
     secure: QXcvN8IXOK95N5MPCXLWdQ3+PxuISMboekkryugpv8NhR9H5kxts6kTQ8pe3P8kc67S3DhD6hoD70AQPvdiiv1+HeOPgHgQn9GONHnmygvQZ/soPK5tsilKu657Qt3Otxx/qliPXZjFZjBVZwsYU04f0PJmE2kpwK72rr95Z6DBMQLBmOLB+CIo7CtoMXG7Jmbt0lsTkR+JoLZJNIKqA3RvlVFkcPFIHrLmBfz0YyalshNc1nYjleW3Y07J+D2BSRrqAWmpzdKc9fUNelBF0aHuIEJvRM7XLPpFrvAlSOVtbMAW8AkZe9rwkOg6MkWOA1POwRLXujwTNbrgfVQivyWqggB/CIycvz1JyTlG61X5iWQK+frcYNIEUcU66lTkjyFuCsuOBOuO6sfGTSUYTMBDk5YES2ZQVGUSkgL20CAMY8L7vuea6aimrsYgw48PQzCvQGFdNw3DVgidOJxbjuriT8okWWBm9ICSlGC2llIsvjvIGS+77bus+VfotPdgr5wV+RhfuAFlgpYkcQnDuxj0LA/xd9xHcw1xtav9XjmpMCPZE1ATxLzciG/yj2+npJ39NdtEhlbuj4pWMxI6IFLJ9m7ksK6QCe5W+yHvKKuJAMjKj2tza3v4hnhxgMed1B8jTR9lwSxmqOqMxfRGj0v2G/wgHxn/Qnqsx7k9X++U=
   on:
     tags: true
-email: systems@azavea.com
-provider: npm


### PR DESCRIPTION
The deploy [failed](https://travis-ci.org/azavea/tilejson-validator/builds/282508056) because of a missing provider. The travis file that was generated didn't match up to the [instructions](https://docs.travis-ci.com/user/deployment/npm/) which ask for `provider` and `email` to be under `deploy`. Hopefully this will work? 